### PR TITLE
Remove 'impure' prefix from function declaration

### DIFF
--- a/ScalableTestSuite/Electrical/DistributionSystemAC.mo
+++ b/ScalableTestSuite/Electrical/DistributionSystemAC.mo
@@ -189,7 +189,7 @@ package DistributionSystemAC
     end DistributionSystemLinear;
 
     model DistributionSystemLinearIndividual
-      impure function print
+      function print
         input String s;
       algorithm
         Modelica.Utilities.Streams.print(s, "code.mo");


### PR DESCRIPTION
The library has the annotation uses(Modelica(version="3.2.2")), but declares a function using the 'impure' prefix introduced in Modelica 3.3.